### PR TITLE
Add comprehensive unit tests for i18n, filters, and utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs": "npx quartz build --serve -d docs",
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
-    "test": "tsx ./quartz/util/path.test.ts && tsx ./quartz/depgraph.test.ts",
+    "test": "tsx ./quartz/util/path.test.ts && tsx ./quartz/depgraph.test.ts && tsx ./quartz/util/escape.test.ts && tsx ./quartz/util/lang.test.ts && tsx ./quartz/plugins/filters/filters.test.ts && tsx ./quartz/i18n/i18n.test.ts",
     "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1"
   },
   "engines": {

--- a/quartz/i18n/i18n.test.ts
+++ b/quartz/i18n/i18n.test.ts
@@ -1,0 +1,102 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { TRANSLATIONS, i18n, defaultTranslation } from "./index"
+import type { ValidLocale } from "./index"
+
+describe("i18n", () => {
+  test("defaultTranslation is a valid locale key", () => {
+    assert.ok(defaultTranslation in TRANSLATIONS, `"${defaultTranslation}" not found in TRANSLATIONS`)
+  })
+
+  test("i18n() returns the translation for a given locale", () => {
+    const t = i18n("en-US")
+    assert.strictEqual(typeof t.propertyDefaults.title, "string")
+    assert.strictEqual(typeof t.propertyDefaults.description, "string")
+  })
+
+  const locales = Object.keys(TRANSLATIONS) as ValidLocale[]
+
+  describe("all locales have required top-level keys", () => {
+    for (const locale of locales) {
+      test(locale, () => {
+        const t = TRANSLATIONS[locale]
+        assert.ok(t.propertyDefaults, `${locale}: missing propertyDefaults`)
+        assert.strictEqual(typeof t.propertyDefaults.title, "string", `${locale}: propertyDefaults.title must be a string`)
+        assert.strictEqual(typeof t.propertyDefaults.description, "string", `${locale}: propertyDefaults.description must be a string`)
+        assert.ok(t.components, `${locale}: missing components`)
+        assert.ok(t.pages, `${locale}: missing pages`)
+      })
+    }
+  })
+
+  describe("all locales have required callout translations", () => {
+    const requiredCallouts = [
+      "note", "abstract", "info", "todo", "tip",
+      "success", "question", "warning", "failure", "danger",
+      "bug", "example", "quote",
+    ] as const
+
+    for (const locale of locales) {
+      test(locale, () => {
+        const callout = TRANSLATIONS[locale].components.callout
+        for (const key of requiredCallouts) {
+          assert.strictEqual(
+            typeof callout[key],
+            "string",
+            `${locale}: callout.${key} must be a string`,
+          )
+        }
+      })
+    }
+  })
+
+  describe("all locales have required page translations", () => {
+    for (const locale of locales) {
+      test(locale, () => {
+        const { pages } = TRANSLATIONS[locale]
+
+        assert.ok(pages.error, `${locale}: missing pages.error`)
+        assert.strictEqual(typeof pages.error.title, "string", `${locale}: pages.error.title`)
+        assert.strictEqual(typeof pages.error.notFound, "string", `${locale}: pages.error.notFound`)
+        assert.strictEqual(typeof pages.error.home, "string", `${locale}: pages.error.home`)
+
+        assert.ok(pages.folderContent, `${locale}: missing pages.folderContent`)
+        assert.strictEqual(typeof pages.folderContent.folder, "string", `${locale}: pages.folderContent.folder`)
+        assert.strictEqual(typeof pages.folderContent.itemsUnderFolder, "function", `${locale}: pages.folderContent.itemsUnderFolder must be a function`)
+
+        assert.ok(pages.tagContent, `${locale}: missing pages.tagContent`)
+        assert.strictEqual(typeof pages.tagContent.tag, "string", `${locale}: pages.tagContent.tag`)
+        assert.strictEqual(typeof pages.tagContent.tagIndex, "string", `${locale}: pages.tagContent.tagIndex`)
+        assert.strictEqual(typeof pages.tagContent.itemsUnderTag, "function", `${locale}: pages.tagContent.itemsUnderTag must be a function`)
+        assert.strictEqual(typeof pages.tagContent.showingFirst, "function", `${locale}: pages.tagContent.showingFirst must be a function`)
+        assert.strictEqual(typeof pages.tagContent.totalTags, "function", `${locale}: pages.tagContent.totalTags must be a function`)
+      })
+    }
+  })
+
+  describe("callable translation functions return strings", () => {
+    for (const locale of locales) {
+      test(locale, () => {
+        const t = TRANSLATIONS[locale]
+
+        const recentNotes = t.components.recentNotes.seeRemainingMore({ remaining: 5 })
+        assert.strictEqual(typeof recentNotes, "string", `${locale}: seeRemainingMore must return a string`)
+
+        const readingTime = t.components.contentMeta.readingTime({ minutes: 3 })
+        assert.strictEqual(typeof readingTime, "string", `${locale}: readingTime must return a string`)
+
+        const folderItems = t.pages.folderContent.itemsUnderFolder({ count: 2 })
+        assert.strictEqual(typeof folderItems, "string", `${locale}: itemsUnderFolder must return a string`)
+
+        const folderSingular = t.pages.folderContent.itemsUnderFolder({ count: 1 })
+        assert.strictEqual(typeof folderSingular, "string", `${locale}: itemsUnderFolder(1) must return a string`)
+
+        const tagItems = t.pages.tagContent.itemsUnderTag({ count: 2 })
+        assert.strictEqual(typeof tagItems, "string", `${locale}: itemsUnderTag must return a string`)
+
+        const totalTags = t.pages.tagContent.totalTags({ count: 10 })
+        assert.strictEqual(typeof totalTags, "string", `${locale}: totalTags must return a string`)
+      })
+    }
+  })
+})

--- a/quartz/plugins/filters/filters.test.ts
+++ b/quartz/plugins/filters/filters.test.ts
@@ -1,0 +1,60 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { RemoveDrafts } from "./draft"
+import { ExplicitPublish } from "./explicit"
+
+// Minimal mock vfile with only the frontmatter fields each filter reads
+function makeVFile(frontmatter: Record<string, unknown>) {
+  return { data: { frontmatter } } as any
+}
+
+const ctx = {} as any
+const tree = {} as any
+
+describe("RemoveDrafts", () => {
+  const filter = RemoveDrafts()
+
+  test("publishes a file with no draft flag", () => {
+    const vfile = makeVFile({})
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), true)
+  })
+
+  test("publishes a file with draft: false", () => {
+    const vfile = makeVFile({ draft: false })
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), true)
+  })
+
+  test("suppresses a file with draft: true", () => {
+    const vfile = makeVFile({ draft: true })
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), false)
+  })
+
+  test("publishes when frontmatter is missing entirely", () => {
+    const vfile = { data: {} } as any
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), true)
+  })
+})
+
+describe("ExplicitPublish", () => {
+  const filter = ExplicitPublish()
+
+  test("suppresses a file with no publish flag", () => {
+    const vfile = makeVFile({})
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), false)
+  })
+
+  test("publishes a file with publish: true", () => {
+    const vfile = makeVFile({ publish: true })
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), true)
+  })
+
+  test("suppresses a file with publish: false", () => {
+    const vfile = makeVFile({ publish: false })
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), false)
+  })
+
+  test("suppresses when frontmatter is missing entirely", () => {
+    const vfile = { data: {} } as any
+    assert.strictEqual(filter.shouldPublish(ctx, [tree, vfile]), false)
+  })
+})

--- a/quartz/util/escape.test.ts
+++ b/quartz/util/escape.test.ts
@@ -1,0 +1,46 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { escapeHTML } from "./escape"
+
+describe("escapeHTML", () => {
+  test("escapes ampersand", () => {
+    assert.strictEqual(escapeHTML("a&b"), "a&amp;b")
+  })
+
+  test("escapes less-than", () => {
+    assert.strictEqual(escapeHTML("<div>"), "&lt;div&gt;")
+  })
+
+  test("escapes greater-than", () => {
+    assert.strictEqual(escapeHTML("a>b"), "a&gt;b")
+  })
+
+  test("escapes double quote", () => {
+    assert.strictEqual(escapeHTML('"hello"'), "&quot;hello&quot;")
+  })
+
+  test("escapes single quote", () => {
+    assert.strictEqual(escapeHTML("it's"), "it&#039;s")
+  })
+
+  test("escapes all special characters together", () => {
+    assert.strictEqual(
+      escapeHTML(`<a href="test" class='x'>a&b</a>`),
+      "&lt;a href=&quot;test&quot; class=&#039;x&#039;&gt;a&amp;b&lt;/a&gt;",
+    )
+  })
+
+  test("ampersand is escaped before < and > to avoid double-escaping", () => {
+    // If & were escaped last, "&lt;" would become "&amp;lt;" — this confirms it doesn't
+    const result = escapeHTML("&lt;")
+    assert.strictEqual(result, "&amp;lt;")
+  })
+
+  test("returns empty string unchanged", () => {
+    assert.strictEqual(escapeHTML(""), "")
+  })
+
+  test("returns plain text unchanged", () => {
+    assert.strictEqual(escapeHTML("hello world"), "hello world")
+  })
+})

--- a/quartz/util/lang.test.ts
+++ b/quartz/util/lang.test.ts
@@ -1,0 +1,51 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { capitalize, classNames } from "./lang"
+
+describe("capitalize", () => {
+  test("capitalizes the first character", () => {
+    assert.strictEqual(capitalize("hello"), "Hello")
+  })
+
+  test("leaves already-capitalized string unchanged", () => {
+    assert.strictEqual(capitalize("Hello"), "Hello")
+  })
+
+  test("handles single character", () => {
+    assert.strictEqual(capitalize("a"), "A")
+  })
+
+  test("only changes the first character", () => {
+    assert.strictEqual(capitalize("hELLO"), "HELLO")
+  })
+
+  test("handles empty string", () => {
+    assert.strictEqual(capitalize(""), "")
+  })
+})
+
+describe("classNames", () => {
+  test("joins multiple class strings", () => {
+    assert.strictEqual(classNames(undefined, "foo", "bar"), "foo bar")
+  })
+
+  test("prepends displayClass when provided", () => {
+    assert.strictEqual(classNames("mobile-only", "foo", "bar"), "foo bar mobile-only")
+  })
+
+  test("prepends desktop-only displayClass", () => {
+    assert.strictEqual(classNames("desktop-only", "nav"), "nav desktop-only")
+  })
+
+  test("handles no extra classes with a displayClass", () => {
+    assert.strictEqual(classNames("mobile-only"), "mobile-only")
+  })
+
+  test("handles no arguments", () => {
+    assert.strictEqual(classNames(undefined), "")
+  })
+
+  test("handles single class without displayClass", () => {
+    assert.strictEqual(classNames(undefined, "only-class"), "only-class")
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit test coverage for several core modules in the Quartz codebase, including internationalization (i18n), content filters, and utility functions.

## Key Changes
- **i18n tests** (`quartz/i18n/i18n.test.ts`): Added 102 lines of tests validating:
  - Default translation locale is valid
  - All locales have required top-level keys (propertyDefaults, components, pages)
  - All locales include required callout translations (13 types)
  - All locales have required page translations (error, folderContent, tagContent)
  - Callable translation functions return strings with proper parameters

- **Filter tests** (`quartz/plugins/filters/filters.test.ts`): Added 60 lines of tests for:
  - `RemoveDrafts` filter behavior with draft flag variations
  - `ExplicitPublish` filter behavior with publish flag requirements
  - Edge cases like missing frontmatter

- **Utility function tests**:
  - `quartz/util/lang.test.ts`: Tests for `capitalize()` and `classNames()` functions covering edge cases (empty strings, single characters, undefined values)
  - `quartz/util/escape.test.ts`: Tests for `escapeHTML()` function validating proper escaping of HTML special characters (&, <, >, ", ') and preventing double-escaping

- **package.json**: Updated test script to run all new test files via tsx

## Notable Implementation Details
- Tests use Node's built-in `test` and `describe` APIs from `node:test`
- i18n tests are parameterized to validate all available locales
- Filter tests use minimal mock vfiles with only required frontmatter fields
- HTML escape tests include a specific case validating ampersand is escaped before angle brackets to prevent double-escaping

https://claude.ai/code/session_01GjH5jMYimtxDYp12zd2LHk